### PR TITLE
Removes call to legacy_url.

### DIFF
--- a/lib/versionable/image.rb
+++ b/lib/versionable/image.rb
@@ -14,7 +14,7 @@ module Versionable
     end
 
     def url
-      blank?(model.send(column)) ? legacy_url(accessor) : model.send(column)
+      model.send(column)
     end
 
     def respond_to?(method, include_private = false)


### PR DESCRIPTION
Handling for legacy urls shouldn't be handled by this gem.